### PR TITLE
Potential fix for code scanning alert no. 4: URL redirection from remote source

### DIFF
--- a/PDMS/accounts/views.py
+++ b/PDMS/accounts/views.py
@@ -1,5 +1,7 @@
 from urllib import request
+from urllib.parse import urlencode
 from django.shortcuts import get_object_or_404, render, redirect
+from django.urls import reverse
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
@@ -109,8 +111,10 @@ def _sync_task_backlog_state(task):
 
 def _redirect_to_sprint_board(request, selected_sprint_id=""):
     safe_sprint_id = str(selected_sprint_id).strip()
+    base_url = reverse('sprint_board_page')
     if safe_sprint_id.isdigit():
-        return redirect(f"?sprint={safe_sprint_id}")
+        query = urlencode({'sprint': safe_sprint_id})
+        return redirect(f"{base_url}?{query}")
     return redirect('sprint_board_page')
 
 

--- a/PDMS/accounts/views.py
+++ b/PDMS/accounts/views.py
@@ -108,8 +108,9 @@ def _sync_task_backlog_state(task):
 
 
 def _redirect_to_sprint_board(request, selected_sprint_id=""):
-    if selected_sprint_id:
-        return redirect(f"{request.path}?sprint={selected_sprint_id}")
+    safe_sprint_id = str(selected_sprint_id).strip()
+    if safe_sprint_id.isdigit():
+        return redirect(f"?sprint={safe_sprint_id}")
     return redirect('sprint_board_page')
 
 

--- a/PDMS/accounts/views.py
+++ b/PDMS/accounts/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db.models import Case, IntegerField, Value, When
+from django.utils.http import url_has_allowed_host_and_scheme
 from .forms import (
     BacklogGroomForm,
     BacklogItemForm,
@@ -112,9 +113,25 @@ def _sync_task_backlog_state(task):
 def _redirect_to_sprint_board(request, selected_sprint_id=""):
     safe_sprint_id = str(selected_sprint_id).strip()
     base_url = reverse('sprint_board_page')
+    allowed_hosts = {request.get_host()}
+
     if safe_sprint_id.isdigit():
         query = urlencode({'sprint': safe_sprint_id})
-        return redirect(f"{base_url}?{query}")
+        target_url = f"{base_url}?{query}"
+        if url_has_allowed_host_and_scheme(
+            target_url,
+            allowed_hosts=allowed_hosts,
+            require_https=request.is_secure(),
+        ):
+            return redirect(target_url)
+        return redirect('sprint_board_page')
+
+    if url_has_allowed_host_and_scheme(
+        base_url,
+        allowed_hosts=allowed_hosts,
+        require_https=request.is_secure(),
+    ):
+        return redirect(base_url)
     return redirect('sprint_board_page')
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/tousarM/Agile_Wildcats/security/code-scanning/4](https://github.com/tousarM/Agile_Wildcats/security/code-scanning/4)

To fix this without changing behavior, stop building the redirect URL from `request.path` and untrusted text. Instead:

1. Validate/normalize `selected_sprint_id` to digits only (or drop it).
2. Redirect to a fixed internal named view (`'sprint_board_page'`).
3. Append query string only after validation.

In `PDMS/accounts/views.py`, update `_redirect_to_sprint_board` (lines around 110–113) so it:
- normalizes `selected_sprint_id` to a string,
- keeps it only if numeric,
- returns `redirect('sprint_board_page')` when empty/invalid,
- returns `redirect(f"/sprints/?sprint={safe_id}")` style only if you have a guaranteed fixed internal path.

Best within shown snippet and minimal risk: keep redirect target internal by named route for fallback and only use a relative query-string redirect derived from sanitized numeric ID.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
